### PR TITLE
Output selection for Qt6 bug workaround

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -32,6 +32,7 @@ INCLUDEPATH += . # without this lupdate shows errors: Qualifying with unknown na
 
 SOURCES += \
     about_ui/aboutdialog.cpp \
+    audio_device_ui/devicesmenu.cpp \
     busyspinner.cpp \
     config/global.cpp \
     config/local.cpp \
@@ -46,6 +47,7 @@ SOURCES += \
     mainmenu.cpp \
     mainwindow.cpp \
     directory_ui/directorymodel.cpp \
+    playback/audiodevice.cpp \
     playback/controls.cpp \
     playback/dispatch.cpp \
     playback/mediaplayer.cpp \
@@ -89,6 +91,7 @@ SOURCES += \
 
 HEADERS += \
     about_ui/aboutdialog.h \
+    audio_device_ui/devicesmenu.h \
     busyspinner.h \
     config/global.h \
     config/local.h \
@@ -102,6 +105,7 @@ HEADERS += \
     mainmenu.h \
     mainwindow.h \
     directory_ui/directorymodel.h \
+    playback/audiodevice.h \
     playback/controls.h \
     playback/dispatch.h \
     playback/mediaplayer.h \

--- a/app/audio_device_ui/devicesmenu.cpp
+++ b/app/audio_device_ui/devicesmenu.cpp
@@ -1,0 +1,25 @@
+#include "audio_device_ui/devicesmenu.h"
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+
+#include <QMediaDevices>
+#include <QAudioDevice>
+
+namespace AudioDeviceUi {
+  DevicesMenu::DevicesMenu(QWidget *parent, Config::Local &local_c) : QMenu(parent), local_conf(local_c) {
+    auto devices = QMediaDevices::audioOutputs();
+    for (auto &device : devices) {
+      auto action = new QAction(this);
+      action->setText(device.description());
+      action->setCheckable(true);
+      action->setProperty("device_id", device.id());
+      connect(action, &QAction::triggered, [=](bool checked) {
+        qDebug() << "triggered" << checked << action->property("device_id");
+      });
+
+      addAction(action);
+    }
+  }
+} // namespace AudioDeviceUi
+
+#endif

--- a/app/audio_device_ui/devicesmenu.h
+++ b/app/audio_device_ui/devicesmenu.h
@@ -1,0 +1,35 @@
+#ifndef DEVICESMENU_H
+#define DEVICESMENU_H
+
+#include <QObject>
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+
+#include "config/local.h"
+
+#include <QToolButton>
+#include <QAction>
+#include <QMenu>
+#include <QWidget>
+#include <QDebug>
+#include <QList>
+
+namespace AudioDeviceUi {
+
+class DevicesMenu : public QMenu
+{
+  Q_OBJECT
+public:
+  explicit DevicesMenu(QWidget *parent, Config::Local &local_c);
+
+signals:
+
+private:
+  Config::Local &local_conf;
+};
+
+} // namespace AudioDeviceUi
+
+#endif
+
+#endif // DEVICESMENU_H

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -75,6 +75,7 @@ MainWindow::MainWindow(const QStringList &args, IPC::Instance *instance, Config:
   setupPlaybackLog();
   setupSortMenu();
   setupSleepLock();
+  setupOutputDevice();
 
   preloadPlaylist(args);
 
@@ -427,6 +428,21 @@ void MainWindow::setupSleepLock() {
   connect(player, &Playback::Controller::stopped, [=]() {
     sleep_lock->activate(false);
   });
+}
+
+void MainWindow::setupOutputDevice() {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+  connect(ui->toolButtonOutputDevice, &QToolButton::clicked, [=]() {
+    std::shared_ptr<AudioDeviceUi::DevicesMenu> device_menu(new AudioDeviceUi::DevicesMenu(this, local_conf));
+    int menu_width = device_menu->sizeHint().width();
+    int x = ui->toolButtonOutputDevice->width() - menu_width;
+    int y = ui->toolButtonOutputDevice->height();
+    QPoint pos(ui->toolButtonOutputDevice->mapToGlobal(QPoint(x, y)));
+    device_menu->exec(pos);
+  });
+#else
+  ui->toolButtonOutputDevice->setVisible(false);
+#endif
 }
 
 void MainWindow::preloadPlaylist(const QStringList &args) {

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -18,6 +18,7 @@
 #include "sort_ui/sortmenu.h"
 #include "ipc/instance.h"
 #include "sleeplock.h"
+#include "audio_device_ui/devicesmenu.h"
 
 #include <QMainWindow>
 #include <QtGlobal>
@@ -81,6 +82,7 @@ private:
   void setupPlaybackLog();
   void setupSortMenu();
   void setupSleepLock();
+  void setupOutputDevice();
 
   void preloadPlaylist(const QStringList &args);
   

--- a/app/mainwindow.ui
+++ b/app/mainwindow.ui
@@ -102,7 +102,7 @@
          <string>Sort</string>
         </property>
         <property name="toolButtonStyle">
-         <enum>Qt::ToolButtonTextBesideIcon</enum>
+         <enum>Qt::ToolButtonStyle::ToolButtonTextBesideIcon</enum>
         </property>
        </widget>
       </item>
@@ -115,7 +115,14 @@
          <string/>
         </property>
         <property name="toolButtonStyle">
-         <enum>Qt::ToolButtonTextBesideIcon</enum>
+         <enum>Qt::ToolButtonStyle::ToolButtonTextBesideIcon</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="toolButtonOutputDevice">
+        <property name="text">
+         <string>Output</string>
         </property>
        </widget>
       </item>
@@ -131,7 +138,7 @@
     <item>
      <widget class="QSplitter" name="splitter">
       <property name="orientation">
-       <enum>Qt::Horizontal</enum>
+       <enum>Qt::Orientation::Horizontal</enum>
       </property>
       <widget class="QWidget" name="layoutWidget">
        <layout class="QVBoxLayout" name="verticalLayout">

--- a/app/playback/audiodevice.cpp
+++ b/app/playback/audiodevice.cpp
@@ -1,0 +1,23 @@
+#include "audiodevice.h"
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+
+#include <QDebug>
+
+namespace Playback {
+  AudioDevice::AudioDevice(QObject *parent) : QObject(parent) {
+    //qDebug() << audio_output.device().id() << audio_output.device().description();
+    const auto devices = QMediaDevices::audioOutputs();
+    for (const QAudioDevice &device : devices)
+        qDebug() << "Device: " << device.id() << device.description();
+
+    connect(&_devices, &QMediaDevices::audioOutputsChanged, [=]() {
+      qDebug() << "change!";
+      const auto devices = QMediaDevices::audioOutputs();
+      for (const QAudioDevice &device : devices)
+          qDebug() << "Device: " << device.id() << device.description();
+    });
+  }
+} // namespace Playback
+
+#endif

--- a/app/playback/audiodevice.h
+++ b/app/playback/audiodevice.h
@@ -1,0 +1,29 @@
+#ifndef AUDIODEVICE_H
+#define AUDIODEVICE_H
+
+#include <QObject>
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+
+#include <QAudioDevice>
+#include <QMediaDevices>
+#include <QAudioSink>
+
+namespace Playback {
+  class AudioDevice : public QObject {
+    Q_OBJECT
+  public:
+    explicit AudioDevice(QObject *parent = nullptr);
+
+  signals:
+    void changed(QAudioDevice device);
+
+  private:
+    QMediaDevices _devices;
+
+  };
+} // namespace Playback
+
+#endif
+
+#endif // AUDIODEVICE_H

--- a/app/playback/playbackcontroller.h
+++ b/app/playback/playbackcontroller.h
@@ -4,6 +4,7 @@
 #include "controls.h"
 #include "track.h"
 #include "playback/mediaplayer.h"
+#include "playback/audiodevice.h"
 
 #include <QObject>
 #include <memory>
@@ -61,6 +62,9 @@ namespace Playback {
     Track _current_track;
     bool next_after_stop;
     QTimer monotonic_timer;
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    Playback::AudioDevice _audio_device;
+#endif
 
   private slots:
     void on_positionChanged(quint64 pos);


### PR DESCRIPTION
Output device selection UI
Workaround for this: https://forum.qt.io/topic/158726/qtmultimedia-6-qpulseaudiosink-how-to-set-stream-name?_=1732964213998